### PR TITLE
Fixed hot cache update on calls to Set()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 .DS_Store
 vendor
+.aider*
+.env

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ $(GOLANGCI_LINT): ## Download Go linter
 
 .PHONY: ci
 ci: tidy lint test
-	go mod tidy && git diff --exit-code
+	@echo
+	@echo "\033[32mEVERYTHING PASSED!\033[0m"
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run Go linter

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ func ExampleUsage() {
     defer cancel()
 
     // ListenAndServe is a convenience function which Starts an instance of groupcache 
-    // with the provided transport and listens for groupcache HTTP requests on the address provided.
+    // with the provided transport and listens for groupcache HTTP requests on
+    // the address provided.
     d, err := groupcache.ListenAndServe(ctx, "192.168.1.1:8080", groupcache.Options{})
     if err != nil {
         log.Fatal("while starting server on 192.168.1.1:8080")

--- a/instance.go
+++ b/instance.go
@@ -169,13 +169,13 @@ func (i *Instance) NewGroup(name string, cacheBytes int64, getter Getter) (Group
 		return nil, fmt.Errorf("duplicate registration of group '%s'", name)
 	}
 	g := &group{
-		instance:    i,
-		name:        name,
-		getter:      getter,
-		cacheBytes:  cacheBytes,
-		loadGroup:   &singleflight.Group{},
-		setGroup:    &singleflight.Group{},
-		removeGroup: &singleflight.Group{},
+		instance:      i,
+		name:          name,
+		getter:        getter,
+		maxCacheBytes: cacheBytes,
+		loadGroup:     &singleflight.Group{},
+		setGroup:      &singleflight.Group{},
+		removeGroup:   &singleflight.Group{},
 	}
 	if err := g.ResetCacheSize(cacheBytes); err != nil {
 		return nil, err

--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -263,7 +263,7 @@ func (t *HttpTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	type transportMethods interface {
 		Get(ctx context.Context, key string, dest Sink) error
-		LocalSet(string, []byte, time.Time)
+		RemoteSet(string, []byte, time.Time)
 		LocalRemove(string)
 	}
 
@@ -309,8 +309,7 @@ func (t *HttpTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if out.Expire != nil && *out.Expire != 0 {
 			expire = time.Unix(*out.Expire/int64(time.Second), *out.Expire%int64(time.Second))
 		}
-
-		group.LocalSet(*out.Key, out.Value, expire)
+		group.RemoteSet(*out.Key, out.Value, expire)
 		return
 	}
 


### PR DESCRIPTION
### Purpose
@xWiiLLz Reported the hot cache's of remote peers were not updated when calling `Set()`. https://github.com/mailgun/groupcache/pull/69

This PR fixes a long standing TODO where there was some question if the hot cache should always be updated on calls to `Set()`. 

### Resolution
We should ALWAYS update the main cache and delete the key from the hot cache when `Set()` is called.

### Rationale
We do not know when the owning peer may switch to a different node due to cluster topography changes. If an owner belongs to a different node the instant after `Set()` completes, calls to `Get()`, consulting the hot cache, may find the previously set value.

Because we don't know which or when a node in the cluster may become the owner, every node in the cluster should be treated identically.

I left the `hotCache` boolean in the signature of `Set()` as I didn't want to make a version breaking change.