### PR TITLE
feat: :sparkles: add RemoveKeys method to cache and fix some tracer parallel test run bug

### DIFF
--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -47,7 +47,7 @@ func newRecorderTracerProvider() *recorderTracerProvider {
 
 // nolint
 func TestNewTracerUsesGlobalProviderWhenNoneProvided(t *testing.T) {
-	t.Parallel()
+	// Mutates the global OTel tracer provider, so keep this test serial to avoid cross-test interference.
 
 	original := otel.GetTracerProvider()
 	rec := newRecorderTracerProvider()
@@ -63,7 +63,7 @@ func TestNewTracerUsesGlobalProviderWhenNoneProvided(t *testing.T) {
 
 // nolint
 func TestNewTracerRespectsCustomProviderOption(t *testing.T) {
-	t.Parallel()
+	// Mutates the global OTel tracer provider, so keep this test serial to avoid cross-test interference.
 
 	original := otel.GetTracerProvider()
 	defer otel.SetTracerProvider(original)
@@ -82,8 +82,6 @@ func TestNewTracerRespectsCustomProviderOption(t *testing.T) {
 
 // nolint
 func TestWithTracerAttributesAppendsAttributes(t *testing.T) {
-	t.Parallel()
-
 	attrs := []attribute.KeyValue{
 		attribute.String("env", "test"),
 		attribute.Int("shard", 1),
@@ -95,8 +93,6 @@ func TestWithTracerAttributesAppendsAttributes(t *testing.T) {
 
 // nolint
 func TestSpanStartOptionsPoolResetsOnPut(t *testing.T) {
-	t.Parallel()
-
 	tracer := NewTracer()
 
 	opts := tracer.getSpanStartOptions()
@@ -116,8 +112,6 @@ func TestSpanStartOptionsPoolResetsOnPut(t *testing.T) {
 
 // nolint
 func TestAttributesPoolResetsOnPut(t *testing.T) {
-	t.Parallel()
-
 	tracer := NewTracer()
 
 	attrs := tracer.getAttributes()


### PR DESCRIPTION
- Fix some ci pipeline bugs when running tracer in parallel due the global nature of otel tracer
- Add `RemoveKeys` to the `Cache` interface and implement it for mutexCache and OtterCache

This PR should address the issue raised #17. cc: @thrawn01 