### PR TITLE
fix: remove t.Parallel() from tests that modify global tracer provider

### DIFF
--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -47,8 +47,6 @@ func newRecorderTracerProvider() *recorderTracerProvider {
 
 // nolint
 func TestNewTracerUsesGlobalProviderWhenNoneProvided(t *testing.T) {
-	t.Parallel()
-
 	original := otel.GetTracerProvider()
 	rec := newRecorderTracerProvider()
 	otel.SetTracerProvider(rec)
@@ -63,8 +61,6 @@ func TestNewTracerUsesGlobalProviderWhenNoneProvided(t *testing.T) {
 
 // nolint
 func TestNewTracerRespectsCustomProviderOption(t *testing.T) {
-	t.Parallel()
-
 	original := otel.GetTracerProvider()
 	defer otel.SetTracerProvider(original)
 


### PR DESCRIPTION
### Purpose
Fixes flaky test failures in `TestNewTracerUsesGlobalProviderWhenNoneProvided` where the test expected 1 tracer request but received 3.

### Implementation
- Removed `t.Parallel()` from `TestNewTracerUsesGlobalProviderWhenNoneProvided` and `TestNewTracerRespectsCustomProviderOption`
- These tests modify the global `otel.TracerProvider` via `otel.SetTracerProvider()`, which causes race conditions when running in parallel with other tests that also call `NewTracer()`
- Other tracer tests that don't modify global state retain `t.Parallel()` for performance