### PR TITLE
Use provided logger in daemon constructor

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -38,7 +38,9 @@ func ListenAndServe(ctx context.Context, address string, opts Options) (*Daemon,
 	}
 
 	if opts.Transport == nil {
-		opts.Transport = transport.NewHttpTransport(transport.HttpTransportOptions{})
+		opts.Transport = transport.NewHttpTransport(transport.HttpTransportOptions{
+			Logger: opts.Logger,
+		})
 	}
 
 	daemon := &Daemon{


### PR DESCRIPTION
When using `ListenAndServe` without a custom `Transport`, the created default `Transport` now respects a provided `Logger`. Otherwise logs are unexpectedly written using the default logger.